### PR TITLE
Fix `next/link` Usage

### DIFF
--- a/pages/artists/[id].js
+++ b/pages/artists/[id].js
@@ -56,8 +56,11 @@ const Index = withRouter(({ router, artist, albums }) => {
             {albums.map(album => (
               <div key={albums.id} class="relative pb-full">
                 <Link
-                  href={`/artists/${artist.id}/?showAlbum=${album.id}`}
-                  as={`/albums/${album.id}`}
+                  href={{
+                    pathname: '/artists/[id]',
+                    query: { id: artist.id, showAlbum: album.id },
+                  }}
+                  as={`/albums/${encodeURIComponent(album.id)}`}
                   scroll={false}
                   shallow
                 >

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,7 +50,10 @@ const Index = withRouter(({ router, artists }) => {
         <div className="mt-4 grid grid-cols-3 gap-8">
           {artists.map(artist => (
             <div key={artist.id} className="relative pb-full">
-              <Link href={`/artists/${artist.id}`}>
+              <Link
+                href="/artists/[id]"
+                as={`/artists/${encodeURIComponent(artist.id)}`}
+              >
                 <a className="group block absolute inset-0">
                   <img
                     className="h-full w-full object-cover"


### PR DESCRIPTION
This pull request fixes incorrect usage of `next/link`.

A `<Link>`'s `href` must always be the route as it exists on the file system.

```js
// Incorrect:
<Link href="/artists/abc">

// Correct:
<Link href="/artists/[id]" as="/artists/abc" >

// Correct for Instagram-style route:
<Link href="/artists/[id]?id=abc" as="/completely-different">
```

https://nextjs.org/docs/api-reference/next/link#dynamic-routes

---

OP discussion:
https://github.com/zeit/next.js/discussions/11625